### PR TITLE
Conform all WishKitShared models to Equatable protocol

### DIFF
--- a/Sources/WishKitShared/Comment/Request/CreateCommentRequest.swift
+++ b/Sources/WishKitShared/Comment/Request/CreateCommentRequest.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct CreateCommentRequest: Codable {
+public struct CreateCommentRequest: Equatable, Codable {
 
     public let wishId: UUID
 

--- a/Sources/WishKitShared/Comment/Response/CommentResponse.swift
+++ b/Sources/WishKitShared/Comment/Response/CommentResponse.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct CommentResponse: Codable {
+public struct CommentResponse: Equatable, Codable {
 
     public let id: UUID
 

--- a/Sources/WishKitShared/Enum/WishState.swift
+++ b/Sources/WishKitShared/Enum/WishState.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Martin Lasek. All rights reserved.
 //
 
-public enum WishState: String, Codable, CaseIterable {
+public enum WishState: String, Equatable, Codable, CaseIterable {
     case approved
     case implemented
 

--- a/Sources/WishKitShared/Error/ApiError.swift
+++ b/Sources/WishKitShared/Error/ApiError.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Martin Lasek. All rights reserved.
 //
 
-public struct ApiError: Error, Codable {
+public struct ApiError: Equatable, Error, Codable {
 
     public let reason: Reason
 
@@ -14,7 +14,7 @@ public struct ApiError: Error, Codable {
         self.reason = reason
     }
 
-    public enum Reason: String, Codable {
+    public enum Reason: String, Equatable, Codable {
         case requestResultedInError
         case wrongBearerToken
         case unknown

--- a/Sources/WishKitShared/User/Request/UserRequest.swift
+++ b/Sources/WishKitShared/User/Request/UserRequest.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct UserRequest: Codable {
+public struct UserRequest: Equatable, Codable {
 
     public let customID: String?
 

--- a/Sources/WishKitShared/User/Response/UserResponse.swift
+++ b/Sources/WishKitShared/User/Response/UserResponse.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct UserResponse: Codable {
+public struct UserResponse: Equatable, Codable {
 
     public let uuid: UUID
 

--- a/Sources/WishKitShared/Wish/Request/CreateWishRequest.swift
+++ b/Sources/WishKitShared/Wish/Request/CreateWishRequest.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Martin Lasek. All rights reserved.
 //
 
-public struct CreateWishRequest: Codable {
+public struct CreateWishRequest: Equatable, Codable {
 
     public let title: String
 

--- a/Sources/WishKitShared/Wish/Request/VoteWishRequest.swift
+++ b/Sources/WishKitShared/Wish/Request/VoteWishRequest.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct VoteWishRequest: Codable {
+public struct VoteWishRequest: Equatable, Codable {
 
     public let wishId: UUID
 

--- a/Sources/WishKitShared/Wish/Response/CreateWishResponse.swift
+++ b/Sources/WishKitShared/Wish/Response/CreateWishResponse.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Martin Lasek. All rights reserved.
 //
 
-public struct CreateWishResponse: Codable {
+public struct CreateWishResponse: Equatable, Codable {
 
     public let title: String
 

--- a/Sources/WishKitShared/Wish/Response/ListWishResponse.swift
+++ b/Sources/WishKitShared/Wish/Response/ListWishResponse.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Martin Lasek. All rights reserved.
 //
 
-public struct ListWishResponse: Codable {
+public struct ListWishResponse: Equatable, Codable {
 
     public let list: [WishResponse]
 

--- a/Sources/WishKitShared/Wish/Response/VoteWishResponse.swift
+++ b/Sources/WishKitShared/Wish/Response/VoteWishResponse.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct VoteWishResponse: Codable {
+public struct VoteWishResponse: Equatable, Codable {
 
     public let wishId: UUID
 

--- a/Sources/WishKitShared/Wish/Response/WishResponse.swift
+++ b/Sources/WishKitShared/Wish/Response/WishResponse.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct WishResponse: Codable {
+public struct WishResponse: Equatable, Codable {
 
     public let id: UUID
 


### PR DESCRIPTION
This change would be especially useful for any codebase that uses TCA architecture, which requires that state properties are all equatable structs.